### PR TITLE
Fixing handling of relative library paths

### DIFF
--- a/platformio/util.py
+++ b/platformio/util.py
@@ -4,7 +4,7 @@
 import json
 from os import name as os_name
 from os import getcwd, getenv, listdir, makedirs, utime
-from os.path import dirname, expanduser, isdir, isfile, join, realpath
+from os.path import dirname, expanduser, isdir, isfile, join, realpath, abspath
 from platform import system, uname
 from subprocess import PIPE, Popen
 
@@ -51,7 +51,7 @@ def get_lib_dir():
         config = get_project_config()
         if (config.has_section("platformio") and
                 config.has_option("platformio", "lib_dir")):
-            lib_dir = config.get("platformio", "lib_dir")
+            lib_dir = abspath(config.get("platformio", "lib_dir"))
             if lib_dir.startswith("~"):
                 return expanduser(lib_dir)
             else:

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -51,11 +51,10 @@ def get_lib_dir():
         config = get_project_config()
         if (config.has_section("platformio") and
                 config.has_option("platformio", "lib_dir")):
-            lib_dir = abspath(config.get("platformio", "lib_dir"))
+            lib_dir = config.get("platformio", "lib_dir")
             if lib_dir.startswith("~"):
-                return expanduser(lib_dir)
-            else:
-                return lib_dir
+                lib_dir = expanduser(lib_dir)
+            return abspath(lib_dir)
     except NotPlatformProject:
         pass
     return join(get_home_dir(), "lib")

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -4,7 +4,7 @@
 import json
 from os import name as os_name
 from os import getcwd, getenv, listdir, makedirs, utime
-from os.path import dirname, expanduser, isdir, isfile, join, realpath, abspath
+from os.path import abspath, dirname, expanduser, isdir, isfile, join, realpath
 from platform import system, uname
 from subprocess import PIPE, Popen
 


### PR DESCRIPTION
I would like to propose an improvement to the handling of lib_dir. I'm using platformio for an Arduino project and I try to keep the original directory structure as intended by the Arduino IDE. In that way, nobody is forced to use platformio, because Arduino IDE can be used to compile the project, too. I've already used the trick, described in https://github.com/ivankravets/platformio/issues/41 and renamed my main ino file to src.ino. It's a hack, but it works.

Now, there is only one thing left: The library path for the project has to be modified. It is one directory up in the path hierarchy. As the project is checked in to a version control system and platformio should work out of the box without adjusting any properties, I need to be able to set a relative directory path, and not an absolute one in my platformio.ini:

[platformio]
lib_dir = ../libraries

This doesn't work in the current version, because the path is used like this in the build directory, which is nested at least one level deeper in the directory structure. Therefore I propose this fix, which expands the path to an absolute one after reading it from the configuration file. I've already successfully tested this patch in Linux and Windows.
