### PR TITLE
Changing library priority

### DIFF
--- a/platformio/builder/main.py
+++ b/platformio/builder/main.py
@@ -63,8 +63,8 @@ DefaultEnvironment(
     BUILD_DIR=join("$PIOENVS_DIR", "$PIOENV"),
     LIBSOURCE_DIRS=[
         join("$PROJECT_DIR", "lib"),
-        util.get_lib_dir(),
         join("$PLATFORMFW_DIR", "libraries"),
+        util.get_lib_dir(),
     ]
 )
 


### PR DESCRIPTION
It seems, that the order, in which libraries are passed to Scons, is relevant. The current order has the following disadvantage: If there are two versions of  the same library, one located in lib_dir and one located in the platform directory, the library in the platform directory has precedence over the library in lib_dir (at least on my system). I think it should be exactly the other way round.

An example:
We use a modified version of the library SoftwareSerial and have placed the modified version in lib_dir, which resides in our project repository. The original version of SoftwareSerial is still present in /usr/share/arduino/libraries, which is the platform lib directory. When we build our project, the modified version of SoftwareSerial should be used, not the original one.

My proposal for a solution:
Switch the order, in which the library paths are passed to Scons. This works on my Linux and Windows system. But I'm not sure, if this change can have other side effects. What is your opinion?