### PR TITLE
Handle update check error when without internet connection

### DIFF
--- a/platformio/maintenance.py
+++ b/platformio/maintenance.py
@@ -14,7 +14,7 @@ from platformio.commands.install import cli as cmd_install
 from platformio.commands.lib import lib_update as cmd_libraries_update
 from platformio.commands.update import cli as cli_platforms_update
 from platformio.commands.upgrade import get_latest_version
-from platformio.exception import UpgraderFailed
+from platformio.exception import GetLatestVersionError,UpgraderFailed
 from platformio.libmanager import LibraryManager
 from platformio.platforms.base import PlatformFactory
 from platformio.util import get_home_dir, get_lib_dir
@@ -23,9 +23,12 @@ from platformio.util import get_home_dir, get_lib_dir
 def on_platformio_start(ctx):
     telemetry.on_command(ctx)
     after_upgrade(ctx)
-    check_platformio_upgrade()
-    check_internal_updates(ctx, "platforms")
-    check_internal_updates(ctx, "libraries")
+    try:
+        check_platformio_upgrade()
+        check_internal_updates(ctx, "platforms")
+        check_internal_updates(ctx, "libraries")
+    except GetLatestVersionError:
+        click.echo("Failed to check for platformio upgrades")
 
 
 def on_platformio_end(ctx, result):  # pylint: disable=W0613


### PR DESCRIPTION
I was coding while on a plane and hit this error.  I temporarily worked around it by editing the last_check times, but it looks like this should fix it.

amp@AMP-MBP-home:~/Dropbox/Arduino/ObjectLights/platformio/SoundUnit [master]$ platformio run
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/platformio-0.11.0_dev-py2.7.egg/platformio/__main__.py", line 53, in main
    cli(None)
  File "/Library/Python/2.7/site-packages/click/core.py", line 610, in __call__
    return self.main(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/click/core.py", line 590, in main
    rv = self.invoke(ctx)
  File "/Library/Python/2.7/site-packages/click/core.py", line 933, in invoke
    Command.invoke(self, ctx)
  File "/Library/Python/2.7/site-packages/click/core.py", line 782, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Library/Python/2.7/site-packages/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/platformio-0.11.0_dev-py2.7.egg/platformio/__main__.py", line 42, in cli
    maintenance.on_platformio_start(ctx)
  File "/Library/Python/2.7/site-packages/platformio-0.11.0_dev-py2.7.egg/platformio/maintenance.py", line 26, in on_platformio_start
    check_platformio_upgrade()
  File "/Library/Python/2.7/site-packages/platformio-0.11.0_dev-py2.7.egg/platformio/maintenance.py", line 138, in check_platformio_upgrade
    latest_version = get_latest_version()
  File "/Library/Python/2.7/site-packages/platformio-0.11.0_dev-py2.7.egg/platformio/commands/upgrade.py", line 43, in get_latest_version
    "https://pypi.python.org/pypi/platformio/json").json()
  File "/Library/Python/2.7/site-packages/requests/api.py", line 65, in get
    return request('get', url, **kwargs)
  File "/Library/Python/2.7/site-packages/requests/api.py", line 49, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/Library/Python/2.7/site-packages/requests/sessions.py", line 461, in request
    resp = self.send(prep, **send_kwargs)
  File "/Library/Python/2.7/site-packages/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/Library/Python/2.7/site-packages/requests/adapters.py", line 415, in send
    raise ConnectionError(err, request=request)
ConnectionError: ('Connection aborted.', gaierror(8, 'nodename nor servname provided, or not known'))