### PR TITLE
Add "require_upload_port" board option // Resolve #107

### DIFF
--- a/platformio/boards/adafruit.json
+++ b/platformio/boards/adafruit.json
@@ -18,6 +18,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": false
@@ -55,8 +56,8 @@
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,
-            "protocol": "usbtiny",
-            "maximum_size": 8192
+            "maximum_size": 8192,
+            "protocol": "usbtiny"     
         }
     },
 
@@ -74,8 +75,7 @@
         "upload": {
             "maximum_ram_size": 2048,
             "maximum_size": 28672,
-            "protocol": "usbtiny",
-            "speed": 115200
+            "protocol": "usbtiny"
         }
     },
 
@@ -93,8 +93,7 @@
         "upload": {
             "maximum_ram_size": 2048,
             "maximum_size": 28672,
-            "protocol": "usbtiny",
-            "speed": 115200
+            "protocol": "usbtiny"
         }
     },
     "protrinket3ftdi": {
@@ -112,6 +111,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 28672,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -130,6 +130,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 28672,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     }

--- a/platformio/boards/arduino.json
+++ b/platformio/boards/arduino.json
@@ -620,5 +620,31 @@
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
         }
+    },
+    "dueUSB": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-D__SAM3X8E__ -DARDUINO_SAM_DUE -DARDUINO_ARCH_SAM",
+            "f_cpu": "84000000L",
+            "mcu": "at91sam3x8e",
+            "cpu": "cortex-m3",
+            "pid": "0x003e",
+            "usb_product": "Arduino Due",
+            "variant": "arduino_due_x",
+            "vid": "0x2341",
+            "ldscript": "sam3x8e.ld"
+        },
+        "framework": "arduino",
+        "name": "Arduino Due (USB Native Port)",
+        "platform": "atmelsam",
+        "upload": {
+            "disable_flushing": true,
+            "maximum_ram_size": 28672,
+            "maximum_size": 524288,
+            "protocol": "sam-ba",
+            "require_upload_port" : true, 
+            "use_1200bps_touch": true,
+            "wait_for_upload_port": true
+        }
     }
 }

--- a/platformio/boards/arduino.json
+++ b/platformio/boards/arduino.json
@@ -18,6 +18,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -38,6 +39,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 14336,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -56,6 +58,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 7168,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -75,6 +78,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 14336,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -94,6 +98,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 28672,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -112,6 +117,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 14336,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -130,6 +136,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 30720,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -152,6 +159,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -172,6 +180,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 32256,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -190,6 +199,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 30720,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -212,6 +222,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -232,6 +243,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 14336,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -250,6 +262,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 30720,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -268,6 +281,7 @@
             "maximum_ram_size": 8192,
             "maximum_size": 253952,
             "protocol": "wiring",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -286,6 +300,7 @@
             "maximum_ram_size": 8192,
             "maximum_size": 126976,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -304,6 +319,7 @@
             "maximum_ram_size": 8192,
             "maximum_size": 253952,
             "protocol": "wiring",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -326,6 +342,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -346,6 +363,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 14336,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -364,6 +382,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 28672,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -382,6 +401,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 14336,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -400,6 +420,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 30720,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -418,6 +439,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 14336,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -436,6 +458,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 30720,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -454,6 +477,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 14336,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 19200
         }
     },
@@ -472,6 +496,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 30720,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -494,6 +519,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -518,6 +544,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -538,6 +565,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 32256,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -560,6 +588,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "via_ssh": true,
@@ -587,9 +616,9 @@
             "maximum_ram_size": 28672,
             "maximum_size": 524288,
             "protocol": "sam-ba",
-            "speed": 57600,
+            "require_upload_port" : true, 
             "use_1200bps_touch": true,
-            "wait_for_upload_port": false
+            "wait_for_upload_port": true
         }
     }
 }

--- a/platformio/boards/digistump.json
+++ b/platformio/boards/digistump.json
@@ -8,7 +8,7 @@
             "variant": "digispark_tiny"
         },
         "framework": "arduino",
-        "name": "Digispark (Default - 16.5mhz)",
+        "name": "Digispark (Default - 16 MHz)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,
@@ -25,7 +25,7 @@
             "variant": "digispark_pro"
         },
         "framework": "arduino",
-        "name": "Digispark Pro (Default 16 Mhz)",
+        "name": "Digispark Pro (Default 16 MHz)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,
@@ -42,7 +42,7 @@
             "variant": "digispark_pro32"
         },
         "framework": "arduino",
-        "name": "Digispark Pro (16 Mhz) (32 byte buffer)",
+        "name": "Digispark Pro (16 MHz) (32 byte buffer)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,
@@ -59,7 +59,7 @@
             "variant": "digispark_pro64"
         },
         "framework": "arduino",
-        "name": "Digispark Pro (16 Mhz) (64 byte buffer)",
+        "name": "Digispark Pro (16 MHz) (64 byte buffer)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,

--- a/platformio/boards/digistump.json
+++ b/platformio/boards/digistump.json
@@ -11,12 +11,9 @@
         "name": "Digispark (Default - 16.5mhz)",
         "platform": "atmelavr",
         "upload": {
-            "disable_flushing": false,
             "maximum_ram_size": 512,
             "maximum_size": 6012,
-            "protocol": "digispark",
-            "use_1200bps_touch": false,
-            "wait_for_upload_port": false
+            "protocol": "digispark"
         }
     },
     "digispark-pro": {
@@ -31,12 +28,9 @@
         "name": "Digispark Pro (Default 16 Mhz)",
         "platform": "atmelavr",
         "upload": {
-            "disable_flushing": false,
             "maximum_ram_size": 512,
             "maximum_size": 14844,
-            "protocol": "digispark",
-            "use_1200bps_touch": false,
-            "wait_for_upload_port": false
+            "protocol": "digispark"
         }
     },
     "digispark-pro32": {
@@ -51,12 +45,9 @@
         "name": "Digispark Pro (16 Mhz) (32 byte buffer)",
         "platform": "atmelavr",
         "upload": {
-            "disable_flushing": false,
             "maximum_ram_size": 512,
             "maximum_size": 14844,
-            "protocol": "digispark",
-            "use_1200bps_touch": false,
-            "wait_for_upload_port": false
+            "protocol": "digispark"
         }
     },
     "digispark-pro64": {
@@ -71,12 +62,9 @@
         "name": "Digispark Pro (16 Mhz) (64 byte buffer)",
         "platform": "atmelavr",
         "upload": {
-            "disable_flushing": false,
             "maximum_ram_size": 512,
             "maximum_size": 14844,
-            "protocol": "digispark",
-            "use_1200bps_touch": false,
-            "wait_for_upload_port": false
+            "protocol": "digispark"
         }
     },
     "digix": {
@@ -96,10 +84,11 @@
         "name": "Digistump DigiX",
         "platform": "atmelsam",
         "upload": {
-            "disable_flushing": false,
+            "disable_flushing": true,
             "maximum_ram_size": 28672,
             "maximum_size": 524288,
             "protocol": "sam-ba",
+            "require_upload_port" : true,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
         }

--- a/platformio/boards/engduino.json
+++ b/platformio/boards/engduino.json
@@ -18,6 +18,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -42,6 +43,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -66,6 +68,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true

--- a/platformio/boards/microduino.json
+++ b/platformio/boards/microduino.json
@@ -14,6 +14,7 @@
             "maximum_ram_size": 16384,
             "maximum_size": 130048,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -32,6 +33,7 @@
             "maximum_ram_size": 16384,
             "maximum_size": 130048,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -50,6 +52,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 15872,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -68,6 +71,7 @@
             "maximum_ram_size": 1024,
             "maximum_size": 15872,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     },
@@ -86,6 +90,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 32256,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -103,6 +108,7 @@
         "upload": {
             "maximum_ram_size": 2048,
             "maximum_size": 32256,
+            "require_upload_port" : true,
             "protocol": "arduino",
             "speed": 57600
         }
@@ -125,6 +131,7 @@
             "maximum_ram_size": 2560,
             "maximum_size": 28672,
             "protocol": "avr109",
+            "require_upload_port" : true,
             "speed": 57600,
             "use_1200bps_touch": true,
             "wait_for_upload_port": true
@@ -145,6 +152,7 @@
             "maximum_ram_size": 4096,
             "maximum_size": 64512,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 115200
         }
     },
@@ -163,6 +171,7 @@
             "maximum_ram_size": 4096,
             "maximum_size": 64512,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     }

--- a/platformio/boards/misc.json
+++ b/platformio/boards/misc.json
@@ -14,6 +14,7 @@
             "maximum_ram_size": 2048,
             "maximum_size": 30720,
             "protocol": "arduino",
+            "require_upload_port" : true,
             "speed": 57600
         }
     }

--- a/platformio/boards/misc.json
+++ b/platformio/boards/misc.json
@@ -17,5 +17,57 @@
             "require_upload_port" : true,
             "speed": 57600
         }
+    },
+    "sainSmartDue": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-D__SAM3X8E__ -DARDUINO_SAM_DUE -DARDUINO_ARCH_SAM",
+            "f_cpu": "84000000L",
+            "mcu": "at91sam3x8e",
+            "cpu": "cortex-m3",
+            "pid": "0x003e",
+            "usb_product": "Arduino Due",
+            "variant": "arduino_due_x",
+            "vid": "0x2341",
+            "ldscript": "sam3x8e.ld"
+        },
+        "framework": "arduino",
+        "name": "SainSmart Due (Programming Port)",
+        "platform": "atmelsam",
+        "upload": {
+            "disable_flushing": true,
+            "maximum_ram_size": 28672,
+            "maximum_size": 524288,
+            "protocol": "sam-ba",
+            "require_upload_port" : true, 
+            "use_1200bps_touch": true,
+            "wait_for_upload_port": true
+        }
+    },
+    "sainSmartDueUSB": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-D__SAM3X8E__ -DARDUINO_SAM_DUE -DARDUINO_ARCH_SAM",
+            "f_cpu": "84000000L",
+            "mcu": "at91sam3x8e",
+            "cpu": "cortex-m3",
+            "pid": "0x003e",
+            "usb_product": "Arduino Due",
+            "variant": "arduino_due_x",
+            "vid": "0x2341",
+            "ldscript": "sam3x8e.ld"
+        },
+        "framework": "arduino",
+        "name": "SainSmart Due (USB Native Port)",
+        "platform": "atmelsam",
+        "upload": {
+            "disable_flushing": true,
+            "maximum_ram_size": 28672,
+            "maximum_size": 524288,
+            "protocol": "sam-ba",
+            "require_upload_port" : true, 
+            "use_1200bps_touch": true,
+            "wait_for_upload_port": true
+        }
     }
 }

--- a/platformio/builder/scripts/atmelavr.py
+++ b/platformio/builder/scripts/atmelavr.py
@@ -20,15 +20,15 @@ def BeforeUpload(target, source, env):  # pylint: disable=W0613,W0621
         with open(path, "w") as f:
             f.write(str(value))
 
-    if "usb" not in env.subst("$UPLOAD_PROTOCOL"):
-        env.AutodetectUploadPort()
-        env.Append(
-            UPLOADERFLAGS=[
-                "-b", "$UPLOAD_SPEED",
-                "-P", "$UPLOAD_PORT"
-            ]
-        )
+    upload_options = env.get("BOARD_OPTIONS", {}).get("upload", {})
 
+    if env.subst("$UPLOAD_SPEED"):
+        env.Append(UPLOADERFLAGS=["-b", "$UPLOAD_SPEED"])
+
+    if not upload_options.get("require_upload_port", False):
+        return
+    env.AutodetectUploadPort()
+    env.Append(UPLOADERFLAGS=["-P", "$UPLOAD_PORT"])
     if env.subst("$BOARD") == "raspduino":
         _rpi_sysgpio("/sys/class/gpio/export", 18)
         _rpi_sysgpio("/sys/class/gpio/gpio18/direction", "out")
@@ -36,9 +36,7 @@ def BeforeUpload(target, source, env):  # pylint: disable=W0613,W0621
         sleep(0.1)
         _rpi_sysgpio("/sys/class/gpio/gpio18/value", 0)
         _rpi_sysgpio("/sys/class/gpio/unexport", 18)
-    elif "UPLOAD_PORT" in env:
-        upload_options = env.get("BOARD_OPTIONS", {}).get("upload", {})
-
+    else:
         if not upload_options.get("disable_flushing", False):
             env.FlushSerialBuffer("$UPLOAD_PORT")
 
@@ -63,7 +61,7 @@ if "digispark" in env.get(
             "-c", "$UPLOAD_PROTOCOL",
             "--timeout", "60"
         ],
-        UPLOADHEXCMD='"$UPLOADER" $UPLOADERFLAGS -U flash:w:$SOURCES:i'
+        UPLOADHEXCMD='"$UPLOADER" $UPLOADERFLAGS $SOURCES'
     )
 
 else:


### PR DESCRIPTION
2. Add second upload method through native USB Port for SAM-based boards
3. Add SainSmart Due board