### PR TITLE
Allow own libs per framework's core; Add support for Sanguino, SparkFun boards

### DIFF
--- a/platformio/boards/adafruit.json
+++ b/platformio/boards/adafruit.json
@@ -1,7 +1,7 @@
 {
     "flora8": {
         "build": {
-            "core": ["arduino"],
+            "core": "arduino",
             "extra_flags": "-DARDUINO_ARCH_AVR",
             "f_cpu": "8000000L",
             "mcu": "atmega32u4",
@@ -29,7 +29,7 @@
 
     "trinket3": {
         "build": {
-            "core": ["arduino"],
+            "core": "arduino",
             "extra_flags": "-DARDUINO_ARCH_AVR",
             "f_cpu": "8000000L",
             "mcu": "attiny85",
@@ -49,7 +49,7 @@
 
     "trinket5": {
         "build": {
-            "core": ["arduino"],
+            "core": "arduino",
             "extra_flags": "-DARDUINO_ARCH_AVR",
             "f_cpu": "16000000L",
             "mcu": "attiny85",
@@ -69,7 +69,7 @@
 
     "protrinket3": {
         "build": {
-            "core": ["arduino"],
+            "core": "arduino",
             "extra_flags": "-DARDUINO_ARCH_AVR",
             "f_cpu": "12000000L",
             "mcu": "atmega328p",
@@ -89,7 +89,7 @@
 
     "protrinket5": {
         "build": {
-            "core": ["arduino"],
+            "core": "arduino",
             "extra_flags": "-DARDUINO_ARCH_AVR",
             "f_cpu": "16000000L",
             "mcu": "atmega328p",
@@ -108,7 +108,7 @@
     },
     "protrinket3ftdi": {
         "build": {
-            "core": ["arduino"],
+            "core": "arduino",
             "extra_flags": "-DARDUINO_ARCH_AVR",
             "f_cpu": "16000000L",
             "mcu": "atmega328p",
@@ -120,7 +120,7 @@
         "upload": {
             "maximum_ram_size": 2048,
             "maximum_size": 28672,
-            "protocol": ["arduino"],
+            "protocol": "arduino",
             "require_upload_port" : true,
             "speed": 115200
         },
@@ -129,7 +129,7 @@
     },
     "protrinket5ftdi": {
         "build": {
-            "core": ["arduino"],
+            "core": "arduino",
             "extra_flags": "-DARDUINO_ARCH_AVR",
             "f_cpu": "16000000L",
             "mcu": "atmega328p",
@@ -141,7 +141,7 @@
         "upload": {
             "maximum_ram_size": 2048,
             "maximum_size": 28672,
-            "protocol": ["arduino"],
+            "protocol": "arduino",
             "require_upload_port" : true,
             "speed": 115200
         },

--- a/platformio/boards/adafruit.json
+++ b/platformio/boards/adafruit.json
@@ -76,7 +76,7 @@
             "variant": "eightanaloginputs"
         },
         "frameworks": ["arduino"],
-        "name": "Pro Trinket 3V/12MHz (USB)",
+        "name": "Adafruit Pro Trinket 3V/12MHz (USB)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 2048,
@@ -96,7 +96,7 @@
             "variant": "eightanaloginputs"
         },
         "frameworks": ["arduino"],
-        "name": "Pro Trinket 5V/16MHz (USB)",
+        "name": "Adafruit Pro Trinket 5V/16MHz (USB)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 2048,
@@ -115,7 +115,7 @@
             "variant": "eightanaloginputs"
         },
         "frameworks": ["arduino"],
-        "name": "Pro Trinket 3V/12MHz (FTDI)",
+        "name": "Adafruit Pro Trinket 3V/12MHz (FTDI)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 2048,
@@ -136,7 +136,7 @@
             "variant": "eightanaloginputs"
         },
         "frameworks": ["arduino"],
-        "name": "Pro Trinket 5V/16MHz (USB)",
+        "name": "Adafruit Pro Trinket 5V/16MHz (USB)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 2048,

--- a/platformio/boards/arduino.json
+++ b/platformio/boards/arduino.json
@@ -11,7 +11,7 @@
             "vid": "0x1B4F"
         },
         "frameworks": ["arduino"],
-        "name": "LilyPad Arduino USB",
+        "name": "Arduino LilyPad USB",
         "platform": "atmelavr",
         "upload": {
             "disable_flushing": true,
@@ -259,7 +259,7 @@
             "variant": "standard"
         },
         "frameworks": ["arduino"],
-        "name": "LilyPad Arduino ATmega168",
+        "name": "Arduino LilyPad ATmega168",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 1024,
@@ -280,7 +280,7 @@
             "variant": "standard"
         },
         "frameworks": ["arduino"],
-        "name": "LilyPad Arduino ATmega328",
+        "name": "Arduino LilyPad ATmega328",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 2048,

--- a/platformio/boards/digistump.json
+++ b/platformio/boards/digistump.json
@@ -8,7 +8,7 @@
             "variant": "digispark_tiny"
         },
         "frameworks": ["arduino"],
-        "name": "Digispark (Default - 16 MHz)",
+        "name": "Digistump Digispark (Default - 16 MHz)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,
@@ -27,7 +27,7 @@
             "variant": "digispark_pro"
         },
         "frameworks": ["arduino"],
-        "name": "Digispark Pro (Default 16 MHz)",
+        "name": "Digistump Digispark Pro (Default 16 MHz)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,
@@ -46,7 +46,7 @@
             "variant": "digispark_pro32"
         },
         "frameworks": ["arduino"],
-        "name": "Digispark Pro (16 MHz) (32 byte buffer)",
+        "name": "Digistump Digispark Pro (16 MHz) (32 byte buffer)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,
@@ -65,7 +65,7 @@
             "variant": "digispark_pro64"
         },
         "frameworks": ["arduino"],
-        "name": "Digispark Pro (16 MHz) (64 byte buffer)",
+        "name": "Digistump Digispark Pro (16 MHz) (64 byte buffer)",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 512,

--- a/platformio/boards/misc.json
+++ b/platformio/boards/misc.json
@@ -20,6 +20,7 @@
         "url": "http://www.bitwizard.nl/wiki/index.php/Raspduino",
         "vendor": "BitWizard"
     },
+
     "sainSmartDue": {
         "build": {
             "core": "arduino",
@@ -76,6 +77,7 @@
         "url": "http://www.sainsmart.com/arduino/control-boards/sainsmart-due-atmel-sam3x8e-arm-cortex-m3-board-black.html",
         "vendor": "SainSmart"
     },
+
     "panStampAVR": {
         "build": {
             "core": "panstamp",
@@ -97,6 +99,7 @@
         "url": "http://www.panstamp.com/product/panstamp-avr/",
         "vendor": "PanStamp"
     },
+
     "panStampNRG": {
         "build": {
             "core": "panstamp",
@@ -114,5 +117,114 @@
         },
         "url": "http://www.panstamp.com/product/197/",
         "vendor": "PanStamp"
+    },
+    "reprap_rambo": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_RAMBO",
+            "f_cpu": "16000000L",
+            "mcu": "atmega2560",
+            "variant": "rambo"
+        },
+        "frameworks": ["arduino"],
+        "name": "RepRap RAMBo",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 8192,
+            "maximum_size": 258048,
+            "protocol": "wiring",
+            "require_upload_port" : true,
+            "speed": 115200
+        },
+        "url": "http://reprap.org/wiki/Rambo",
+        "vendor": "RepRap"
+    },
+
+    "sanguino_atmega1284p": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_SANGUINO",
+            "f_cpu": "16000000L",
+            "mcu": "atmega1284p",
+            "variant": "sanguino"
+        },
+        "frameworks": ["arduino"],
+        "name": "Sanguino ATmega1284p (16MHz)",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 16384,
+            "maximum_size": 131072,
+            "protocol": "stk500",
+            "require_upload_port" : true,
+            "speed": 57600
+        },
+        "url": "https://code.google.com/p/sanguino/",
+        "vendor": "Sanguino"
+    },
+
+    "sanguino_atmega12848m": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_SANGUINO",
+            "f_cpu": "8000000L",
+            "mcu": "atmega1284p",
+            "variant": "sanguino"
+        },
+        "frameworks": ["arduino"],
+        "name": "Sanguino ATmega1284p (8MHz)",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 16384,
+            "maximum_size": 131072,
+            "protocol": "stk500",
+            "require_upload_port" : true,
+            "speed": 19200
+        },
+        "url": "https://code.google.com/p/sanguino/",
+        "vendor": "Sanguino"
+    },
+
+    "sanguino_atmega1284m": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_SANGUINO",
+            "f_cpu": "20000000L",
+            "mcu": "atmega1284p",
+            "variant": "sanguino"
+        },
+        "frameworks": ["arduino"],
+        "name": "Sanguino ATmega1284p (20MHz)",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 16384,
+            "maximum_size": 131072,
+            "protocol": "stk500",
+            "require_upload_port" : true,
+            "speed": 19200
+        },
+        "url": "https://code.google.com/p/sanguino/",
+        "vendor": "Sanguino"
+    },
+
+    "sanguino_atmega644p": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_SANGUINO",
+            "f_cpu": "16000000L",
+            "mcu": "atmega644p",
+            "variant": "sanguino"
+        },
+        "frameworks": ["arduino"],
+        "name": "Sanguino ATmega644P",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 4096,
+            "maximum_size": 63488,
+            "protocol": "stk500",
+            "require_upload_port" : true,
+            "speed": 57600
+        },
+        "url": "https://code.google.com/p/sanguino/",
+        "vendor": "Sanguino"
     }
 }

--- a/platformio/boards/misc.json
+++ b/platformio/boards/misc.json
@@ -8,7 +8,7 @@
             "variant": "standard"
         },
         "frameworks": ["arduino"],
-        "name": "Raspduino",
+        "name": "BitWizard Raspduino",
         "platform": "atmelavr",
         "upload": {
             "maximum_ram_size": 2048,

--- a/platformio/boards/nordicnrf51.json
+++ b/platformio/boards/nordicnrf51.json
@@ -118,7 +118,7 @@
             "mcu": "nrf51822"
         },
         "frameworks": ["mbed"],
-        "name": "Seeed Tiny BLE",
+        "name": "SeeedStudio Seeed Tiny BLE",
         "platform": "nordicnrf51",
         "upload": {
             "maximum_ram_size": 16384,

--- a/platformio/boards/nxplpc.json
+++ b/platformio/boards/nxplpc.json
@@ -6,7 +6,7 @@
             "mcu": "lpc1768"
         },
         "frameworks": ["mbed"],
-        "name": "mbed LPC1768",
+        "name": "NXP mbed LPC1768",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 32768,
@@ -22,7 +22,7 @@
             "mcu": "lpc11u24"
         },
         "frameworks": ["mbed"],
-        "name": "mbed LPC11U24",
+        "name": "NXP mbed LPC11U24",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 8192,
@@ -38,7 +38,7 @@
             "mcu": "lpc4088"
         },
         "frameworks": ["mbed"],
-        "name": "EA LPC4088 QuickStart Board",
+        "name": "Embedded Artists LPC4088 QuickStart Board",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 98304,
@@ -54,7 +54,7 @@
             "mcu": "lpc11u24"
         },
         "frameworks": ["mbed"],
-        "name": "DipCortex M0",
+        "name": "Solder Splash Labs DipCortex M0",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 8192,
@@ -70,7 +70,7 @@
             "mcu": "lpc11u24"
         },
         "frameworks": ["mbed"],
-        "name": "BlueBoard-LPC11U24",
+        "name": "NGX Technologies BlueBoard-LPC11U24",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 8192,
@@ -86,7 +86,7 @@
             "mcu": "lpc1768"
         },
         "frameworks": ["mbed"],
-        "name": "Seeeduino-Arch-Pro",
+        "name": "SeeedStudio Seeeduino-Arch-Pro",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 32768,
@@ -118,7 +118,7 @@
             "mcu": "lpc1114fn28"
         },
         "frameworks": ["mbed"],
-        "name": "mbed LPC1114FN28",
+        "name": "Switch Science mbed LPC1114FN28",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 4096,
@@ -134,7 +134,7 @@
             "mcu": "lpc11u35"
         },
         "frameworks": ["mbed"],
-        "name": "EA LPC11U35 QuickStart Board",
+        "name": "Embedded Artists LPC11U35 QuickStart Board",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 10240,
@@ -150,7 +150,7 @@
             "mcu": "lpc11u35"
         },
         "frameworks": ["mbed"],
-        "name": "TG-LPC11U35-501",
+        "name": "CQ Publishing TG-LPC11U35-501",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 10240,
@@ -166,7 +166,7 @@
             "mcu": "lpc1549"
         },
         "frameworks": ["mbed"],
-        "name": "LPCXpresso1549",
+        "name": "NXP LPCXpresso1549",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 36864,
@@ -198,7 +198,7 @@
             "mcu": "lpc4088"
         },
         "frameworks": ["mbed"],
-        "name": "EA LPC4088 Display Module",
+        "name": "Embedded Artists LPC4088 Display Module",
         "platform": "nxplpc",
         "upload": {
             "maximum_ram_size": 98304,

--- a/platformio/boards/sparkfun.json
+++ b/platformio/boards/sparkfun.json
@@ -1,0 +1,191 @@
+ {
+    "sparkfun_redboard": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DARDUINO_AVR_UNO",
+            "f_cpu": "16000000L",
+            "mcu": "atmega328p",
+            "variant": "standard"
+        },
+        "frameworks": ["arduino"],
+        "name": "SparkFun RedBoard",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 2048,
+            "maximum_size": 32256,
+            "protocol": "arduino",
+            "require_upload_port" : true,
+            "speed": 115200
+        },
+        "url": "https://www.sparkfun.com/products/12757",
+        "vendor": "SparkFun"
+    },
+    "sparkfun_promicro16": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_PROMICRO16",
+            "f_cpu": "16000000L",
+            "mcu": "atmega32u4",
+            "pid": "0x9206",
+            "usb_product": "SparkFun Pro Micro",
+            "variant": "sparkfun_promicro",
+            "vid": "0x1B4F"
+        },
+        "frameworks": ["arduino"],
+        "name": "SparkFun Pro Micro 5V/16MHz",
+        "platform": "atmelavr",
+        "upload": {
+            "disable_flushing": true,
+            "maximum_ram_size": 2560,
+            "maximum_size": 28672,
+            "protocol": "avr109",
+            "require_upload_port" : true,
+            "speed": 57600,
+            "use_1200bps_touch": true,
+            "wait_for_upload_port": true
+        },
+        "url": "https://www.sparkfun.com/products/12640",
+        "vendor": "SparkFun"
+    },
+    "sparkfun_promicro8": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_PROMICRO8",
+            "f_cpu": "8000000L",
+            "mcu": "atmega32u4",
+            "pid": "0x9204",
+            "usb_product": "SparkFun Pro Micro",
+            "variant": "sparkfun_promicro",
+            "vid": "0x1B4F"
+        },
+        "frameworks": ["arduino"],
+        "name": "SparkFun Pro Micro 3.3V/8MHz",
+        "platform": "atmelavr",
+        "upload": {
+            "disable_flushing": true,
+            "maximum_ram_size": 2560,
+            "maximum_size": 28672,
+            "protocol": "avr109",
+            "require_upload_port" : true,
+            "speed": 57600,
+            "use_1200bps_touch": true,
+            "wait_for_upload_port": true
+        },
+        "url": "https://www.sparkfun.com/products/12587",
+        "vendor": "SparkFun"
+    },
+    "sparkfun_fiov3": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_FIOV3",
+            "f_cpu": "8000000L",
+            "mcu": "atmega32u4",
+            "pid": "0xF101",
+            "usb_product": "SparkFun Fio v3",
+            "variant": "sparkfun_promicro",
+            "vid": "0x1B4F"
+        },
+        "frameworks": ["arduino"],
+        "name": "SparkFun Fio V3 3.3V/8MHz",
+        "platform": "atmelavr",
+        "upload": {
+            "disable_flushing": true,
+            "maximum_ram_size": 2560,
+            "maximum_size": 28672,
+            "protocol": "avr109",
+            "require_upload_port" : true,
+            "speed": 57600,
+            "use_1200bps_touch": true,
+            "wait_for_upload_port": true
+        },
+        "url": "https://www.sparkfun.com/products/11520",
+        "vendor": "SparkFun"
+    },
+    "sparkfun_makeymakey": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DAVR_MAKEYMAKEY",
+            "f_cpu": "16000000L",
+            "mcu": "atmega32u4",
+            "pid": "0x2B75",
+            "usb_product": "SparkFun MaKey",
+            "variant": "sparkfun_promicro",
+            "vid": "0x1B4F"
+        },
+        "frameworks": ["arduino"],
+        "name": "SparkFun Makey Makey",
+        "platform": "atmelavr",
+        "upload": {
+            "disable_flushing": true,
+            "maximum_ram_size": 2560,
+            "maximum_size": 28672,
+            "protocol": "avr109",
+            "require_upload_port" : true,
+            "speed": 57600,
+            "use_1200bps_touch": true,
+            "wait_for_upload_port": true
+        },
+        "url": "https://www.sparkfun.com/products/11511",
+        "vendor": "SparkFun"
+    },
+    "sparkfun_megapro16MHz": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DARDUINO_AVR_MEGA2560",
+            "f_cpu": "16000000L",
+            "mcu": "atmega2560",
+            "variant": "mega"
+        },
+        "frameworks": ["arduino"],
+        "name": "SparkFun Mega Pro 5V/16MHz",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 8192,
+            "maximum_size": 258048,
+            "protocol": "stk500v2",
+            "speed": 57600
+        },
+        "url": "https://www.sparkfun.com/products/11007",
+        "vendor": "SparkFun"
+    },
+    "sparkfun_megapro8MHz": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DARDUINO_AVR_MEGA2560",
+            "f_cpu": "8000000L",
+            "mcu": "atmega2560",
+            "variant": "mega"
+        },
+        "frameworks": ["arduino"],
+        "name": "SparkFun Mega Pro 3.3V/8MHz",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 8192,
+            "maximum_size": 258048,
+            "protocol": "stk500v2",
+            "speed": 57600
+        },
+        "url": "https://www.sparkfun.com/products/10744",
+        "vendor": "SparkFun"
+    },
+    "sparkfun_megamini": {
+        "build": {
+            "core": "arduino",
+            "extra_flags": "-DARDUINO_ARCH_AVR -DARDUINO_AVR_MEGA2560",
+            "f_cpu": "8000000L",
+            "mcu": "atmega2560",
+            "variant": "mega"
+        },
+        "frameworks": ["arduino"],
+        "name": "SparkFun Mega Pro Mini 3.3V",
+        "platform": "atmelavr",
+        "upload": {
+            "maximum_ram_size": 8192,
+            "maximum_size": 258048,
+            "protocol": "stk500v2",
+            "speed": 57600
+        },
+        "url": "https://www.sparkfun.com/products/10743",
+        "vendor": "SparkFun"
+    }
+}

--- a/platformio/boards/ststm32.json
+++ b/platformio/boards/ststm32.json
@@ -10,7 +10,7 @@
             "variant": "stm32f4"
         },
         "frameworks": ["cmsis", "spl", "libopencm3", "mbed"],
-        "name": "STM32F4DISCOVERY",
+        "name": "ST STM32F4DISCOVERY",
         "platform": "ststm32",
         "upload": {
             "maximum_ram_size": 131072,
@@ -30,7 +30,7 @@
             "variant": "stm32l1"
         },
         "frameworks": ["cmsis","spl","libopencm3"],
-        "name": "STM32LDISCOVERY",
+        "name": "ST STM32LDISCOVERY",
         "platform": "ststm32",
         "upload": {
             "maximum_ram_size": 16384,
@@ -50,7 +50,7 @@
             "variant": "stm32f3"
         },
         "frameworks": ["cmsis", "spl", "libopencm3", "mbed"],
-        "name": "STM32F3DISCOVERY",
+        "name": "ST STM32F3DISCOVERY",
         "platform": "ststm32",
         "upload": {
             "maximum_ram_size": 49152,
@@ -66,7 +66,7 @@
             "mcu": "stm32f100rbt6"
         },
         "frameworks": ["mbed"],
-        "name": "STM32VLDISCOVERY",
+        "name": "ST STM32VLDISCOVERY",
         "platform": "ststm32",
         "upload": {
             "maximum_ram_size": 8192,
@@ -82,7 +82,7 @@
             "mcu": "stm32f051r8t6"
         },
         "frameworks": ["mbed"],
-        "name": "STM32F0DISCOVERY",
+        "name": "ST STM32F0DISCOVERY",
         "platform": "ststm32",
         "upload": {
             "maximum_ram_size": 8192,
@@ -98,7 +98,7 @@
             "mcu": "stm32f334c8t6"
         },
         "frameworks": ["mbed"],
-        "name": "32F3348DISCOVERY",
+        "name": "ST 32F3348DISCOVERY",
         "platform": "ststm32",
         "upload": {
             "maximum_ram_size": 16384,
@@ -114,7 +114,7 @@
             "mcu": "stm32f401vct6"
         },
         "frameworks": ["mbed"],
-        "name": "32F401CDISCOVERY",
+        "name": "ST 32F401CDISCOVERY",
         "platform": "ststm32",
         "upload": {
             "maximum_ram_size": 65536,
@@ -130,7 +130,7 @@
             "mcu": "stm32f429zit6"
         },
         "frameworks": ["mbed"],
-        "name": "32F429IDISCOVERY",
+        "name": "ST 32F429IDISCOVERY",
         "platform": "ststm32",
         "upload": {
             "maximum_ram_size": 262144,

--- a/platformio/boards/timsp430.json
+++ b/platformio/boards/timsp430.json
@@ -7,7 +7,7 @@
             "variant": "launchpad_f5529"
         },
         "frameworks": ["energia"],
-        "name": "LaunchPad w/ msp430f5529 (16MHz)",
+        "name": "TI LaunchPad w/ msp430f5529 (16MHz)",
         "platform": "timsp430",
         "upload": {
             "maximum_ram_size": 1024,
@@ -25,7 +25,7 @@
             "variant": "launchpad_f5529"
         },
         "frameworks": ["energia"],
-        "name": "LaunchPad w/ msp430f5529 (25MHz)",
+        "name": "TI LaunchPad w/ msp430f5529 (25MHz)",
         "platform": "timsp430",
         "upload": {
             "maximum_ram_size": 1024,
@@ -43,7 +43,7 @@
             "variant": "fraunchpad"
         },
         "frameworks": ["energia"],
-        "name": "FraunchPad w/ msp430fr5739",
+        "name": "TI FraunchPad w/ msp430fr5739",
         "platform": "timsp430",
         "upload": {
             "maximum_ram_size": 1024,
@@ -61,7 +61,7 @@
             "variant": "launchpad_fr5969"
         },
         "frameworks": ["energia"],
-        "name": "LaunchPad w/ msp430fr5969",
+        "name": "TI LaunchPad w/ msp430fr5969",
         "platform": "timsp430",
         "upload": {
             "maximum_ram_size": 1024,
@@ -79,7 +79,7 @@
             "variant": "launchpad"
         },
         "frameworks": ["energia"],
-        "name": "LaunchPad w/ msp430g2231 (1 MHz)",
+        "name": "TI LaunchPad w/ msp430g2231 (1 MHz)",
         "platform": "timsp430",
         "upload": {
             "maximum_ram_size": 128,
@@ -97,7 +97,7 @@
             "variant": "launchpad"
         },
         "frameworks": ["energia"],
-        "name": "LaunchPad w/ msp430g2452 (16MHz)",
+        "name": "TI LaunchPad w/ msp430g2452 (16MHz)",
         "platform": "timsp430",
         "upload": {
             "maximum_ram_size": 256,
@@ -115,7 +115,7 @@
             "variant": "launchpad"
         },
         "frameworks": ["energia"],
-        "name": "LaunchPad w/ msp430g2553 (16MHz)",
+        "name": "TI LaunchPad w/ msp430g2553 (16MHz)",
         "platform": "timsp430",
         "upload": {
             "maximum_ram_size": 512,

--- a/platformio/boards/titiva.json
+++ b/platformio/boards/titiva.json
@@ -9,7 +9,7 @@
             "variant": "stellarpad"
         },
         "frameworks": ["energia", "libopencm3"],
-        "name": "LaunchPad (Stellaris) w/ lm4f120 (80MHz)",
+        "name": "TI LaunchPad (Stellaris) w/ lm4f120 (80MHz)",
         "platform": "titiva",
         "upload": {
             "maximum_ram_size": 32768,
@@ -28,7 +28,7 @@
             "variant": "stellarpad"
         },
         "frameworks": ["energia", "libopencm3"],
-        "name": "LaunchPad (Tiva C) w/ tm4c123 (80MHz)",
+        "name": "TI LaunchPad (Tiva C) w/ tm4c123 (80MHz)",
         "platform": "titiva",
         "upload": {
             "maximum_ram_size": 32768,
@@ -47,7 +47,7 @@
             "variant": "launchpad_129"
         },
         "frameworks": ["energia", "libopencm3"],
-        "name": "LaunchPad (Tiva C) w/ tm4c129 (120MHz)",
+        "name": "TI LaunchPad (Tiva C) w/ tm4c129 (120MHz)",
         "platform": "titiva",
         "upload": {
             "maximum_ram_size": 262144,

--- a/platformio/builder/main.py
+++ b/platformio/builder/main.py
@@ -71,7 +71,7 @@ DefaultEnvironment(
     LIBSOURCE_DIRS=[
         join("$PROJECT_DIR", "lib"),
         util.get_lib_dir(),
-        join("$PLATFORMFW_DIR", "libraries"),
+        join("$PLATFORMFW_DIR", "libraries")
     ]
 )
 

--- a/platformio/builder/scripts/frameworks/arduino.py
+++ b/platformio/builder/scripts/frameworks/arduino.py
@@ -12,7 +12,7 @@ http://arduino.cc/en/Reference/HomePage
 """
 
 from os import listdir, walk
-from os.path import isfile, join
+from os.path import isdir, isfile, join
 
 from SCons.Script import DefaultEnvironment
 
@@ -20,6 +20,7 @@ env = DefaultEnvironment()
 
 BOARD_OPTS = env.get("BOARD_OPTIONS", {})
 BOARD_BUILDOPTS = BOARD_OPTS.get("build", {})
+BOARD_CORELIBDIRNAME = BOARD_BUILDOPTS.get("core")
 
 #
 # Determine framework directory
@@ -30,6 +31,7 @@ PLATFORMFW_DIR = join("$PIOPACKAGES_DIR",
                       "framework-arduino${PLATFORM.replace('atmel', '')}")
 
 if "digispark" in BOARD_BUILDOPTS.get("core"):
+    BOARD_CORELIBDIRNAME = "digispark"
     PLATFORMFW_DIR = join(
         "$PIOPACKAGES_DIR",
         "framework-arduino%s" % (
@@ -42,6 +44,21 @@ elif env.get("PLATFORM") == "timsp430":
     )
 
 env.Replace(PLATFORMFW_DIR=PLATFORMFW_DIR)
+
+#
+# Lookup for specific core's libraries
+#
+
+if isdir(join(env.subst("$PLATFORMFW_DIR"), "libraries", "__cores__",
+              BOARD_CORELIBDIRNAME)):
+    lib_dirs = env.get("LIBSOURCE_DIRS")
+    lib_dirs.insert(
+        lib_dirs.index(join("$PLATFORMFW_DIR", "libraries")),
+        join(PLATFORMFW_DIR, "libraries", "__cores__", BOARD_CORELIBDIRNAME)
+    )
+    env.Replace(
+        LIBSOURCE_DIRS=lib_dirs
+    )
 
 #
 # Base


### PR DESCRIPTION
* Add support for SparkFun boards // Resolve #127
* Normalize board names // Resolve #128
* Add support for Sanguino boards // Resolve #131
* Allow own libs per framework's core // Resolve #133